### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -97,4 +97,5 @@ add_clang_library(clangCodeGen
   clangBasic
   clangFrontend
   clangLex
+  clangSema
   )


### PR DESCRIPTION
Fix build link error on both Centos 6.9 and OSX 10.13.4 (with latest Xcode)